### PR TITLE
Add funding information for GitHub Sponsors and Buy Me A Coffee

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# GitHub Sponsors: https://github.com/sponsors/nnellans
+github: nnellans
+
+# Buy Me A Coffee:  https://buymeacoffee.com/nnellans
+buy_me_a_coffee: nnellans

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bicep Guide
 
-- Version: 1.5.0
+- Version: 1.5.1
 - Author:
   - Nathan Nellans
   - Email: me@nathannellans.com
@@ -14,6 +14,9 @@
 
 > [!WARNING]
 > This is a live document.  Some of the sections are still a work in progress.  I will be continually updating it over time.
+
+> [!TIP]
+> AI was not used in the creation of this guide.
 
 > [!NOTE]
 > Here is a link to my own [Bicep Deployment Series](https://www.nathannellans.com/post/all-about-bicep-deploying-bicep-files) which goes over the various nuances of deploying Bicep files.


### PR DESCRIPTION
This pull request includes minor updates to the project documentation and repository configuration. The most important changes are the addition of sponsorship and donation options, an update to the version number, and a clarification about AI usage in the guide.

Repository and funding configuration:

* Added `.github/FUNDING.yml` to enable GitHub Sponsors and Buy Me A Coffee links for supporting the project.

Documentation updates:

* Updated the version in `README.md` from 1.5.0 to 1.5.1.
* Added a note in `README.md` stating that AI was not used in the creation of the guide.